### PR TITLE
change pwa

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,11 +4,10 @@ source "https://rubygems.org"
 
 gem "jekyll","~>4.0.0"
 gem "jekyll-remote-theme"
-
+gem 'jekyll-pwa-plugin', git: 'https://github.com/lavas-project/jekyll-pwa'
 # gem "minimal-ionio-jekyll", path: '../minimal-ionio'  # FOR LOCAL DEVELOPEMNT ONLY, PLEASE READ THE DOCS
 
 group :jekyll_plugins do
-  gem 'jekyll-pwa-plugin'
   gem "jekyll-paginate"
   gem "jekyll-sitemap"
   gem "jekyll-gist"


### PR DESCRIPTION
### Σχετικό Issue
closes #22

### Προτεινόμενες Αλλαγές
-- Αλλαγή τρόπου που καλούμε το plugin PWA

..
Επίσης θα μπορούσε να γίνει και χρήση του παλιού version μέσο:
#gem 'jekyll-pwa-plugin', '2.1.1' , git: 'https://github.com/lavas-project/jekyll-pwa' 

Αυτό μπορεί να είναι καλύτερο για το μέλλον εάν αποφασίσουν να κάνουν περισσότερα updates στο plugin που μπορεί να χαλάσουν το site. Αλλά για τώρα απλά άλλαξα το τρόπο που το καλούμε στο Gemfile

### Υπενθυμίσεις
- [x] Έχω ανοίξει από πριν issue για τον καλό συντονισμό του project, το οποίο έχει πάρει το πράσινο φως με την αντίστοιχη ετικέτα
- [x] Έχω δημιουργήσει branch για τις αλλαγές
