### PR TITLE
Διόρθωση συνδέσμου οδηγού σπουδών

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,8 @@ header:
   video:
     source: "dUsAnW1zYqc"
     playlist: "dUsAnW1zYqc"
-  cta_label: "<i class='fa fa-download'></i> Οδηγός Σπουδών 2019-2020"
-  cta_url: "http://di.ionio.gr/wp-content/uploads/2019/10/DI-PROSPECTUS-2019-2020.pdf"
+  cta_label: "<i class='fa fa-download'></i> Οδηγός Σπουδών 2020 - 2021"
+  cta_url: "https://ionio.gr/download.php?f=00001-00999/IU-pf-00754-97938-gr.pdf"
   caption:
 excerpt: 'Η δράση του Τμήματος Πληροφορικής είναι προσανατολισμένη σε καινοτόμες εφαρμογές στις κατευθύνσεις των:<br /> <small><a href="/humanistic">Ανθρωπιστικών-Κοινωνικών Επιστημών </a></small><br /> <small><a href="/systems">Πληροφοριακών Συστημάτων </a></small><br /><br />'
 feature_row:


### PR DESCRIPTION
### Σχετικό Issue
closes #32 

### Προτεινόμενες Αλλαγές
- Ενημέρωση του συνδέσμου της αρχικής σελίδας προς το pdf του νέου οδηγού σπουδών (ο παλιός δεν υπήρχε)
- Ενημέρωση του τίτλου του συνδέσμου γιατί πλέον αναφέρεται στο ακαδημαϊκό έτος 2020 - 2021

**Σημείωση 1:** Ο νέος σύνδεσμος υπάρχει κανονικά, ωστόσο δεν κατεβαίνει το αρχείο pdf μέσα από το site. Αυτό θα προσπαθήσω να το φτιάξω σε επόμενη συνεισφορά, ανοίγοντας σχετικό issue.
**Σημείωση 2:** Οι αλλαγές δοκιμάστηκαν στη δική μου έκδοση του site και δεν δημιουργήθηκε κανένα πρόβλημα (παρακάτω το link)

### Στοιχεία
- **Ονοματεπώνυμο:** Παύλος Καλλιάρας
- **Α.Μ.:** Π2018021
- **Σύνδεσμος Netlify:** https://compassionate-banach-64b6db.netlify.app

### Υπενθυμίσεις
- [x] Έχω ανοίξει από πριν issue για τον καλό συντονισμό του project, το οποίο έχει πάρει το πράσινο φως με την αντίστοιχη ετικέτα
- [x] Έχω ενημερώσει το issueNo παραπάνω με τον αριθμό του αντίστοιχου θέματος, ώστε να κλείσει αυτόματα με την αποδοχή αυτού του αιτήματος
- [x] Έχω δημιουργήσει branch για τις αλλαγές