### PR TITLE
Προσθήκη Ωρολόγιου Προγράμματος Προπτυχιακoύ ΣΤ' Εξαμήνου

### DIFF
--- a/all_collections/_timetables/sem_f.md
+++ b/all_collections/_timetables/sem_f.md
@@ -25,82 +25,117 @@ timetable:
     location: "Εξ αποστάσεως"
     
   - day: "Τρίτη"
-    time: 11
-    course: discrete-mathematics
+    time: 9
+    course: pattern-recognition
     author: vlamos
-    location: "Αμφιθέατρο 1"
+    location: "Εξ αποστάσεως"
+  - day: "Τρίτη"
+    time: 11
+    course: distributed-network-systems
+    author: hristope
+    location: "Εξ αποστάσεως"
   - day: "Τρίτη"
     time: 13
-    course: computer-programming
-    author: andronikos
-    location: "Εργαστήριο Γαληνός"
+    course: distributed-network-systems
+    author: okon
+    location: "Εξ αποστάσεως"
   - day: "Τρίτη"
     time: 15
-    course: computer-programming
-    author: mistral
-    location: "Εργαστήριο Γαληνός"
+    course: internet-technologies
+    author: dtsouma
+    location: "Εξ αποστάσεως"
+  - day: "Τρίτη"
+    time: 17
+    course: "Συστήματα Υποστήριξης Αποφάσεων"
+    author: exarchos
+    location: "Εξ αποστάσεως"
+  - day: "Τρίτη"
+    time: 19
+    course: "Θεωρία Γραφημάτων και Εφαρμογές"
+    author: karyotis
+    location: "Εξ αποστάσεως"
 
   - day: "Τετάρτη"
     time: 9
-    course: discrete-mathematics
-    author: vlamos
-    location: "Αμφιθέατρο 1"
+    course: "Θεωρία Γραφημάτων και Εφαρμογές"
+    author: karyotis
+    location: "Εξ αποστάσεως"
   - day: "Τετάρτη"
     time: 11
-    course: theory-of-propability
-    author: alex
-    location: "Εργαστήριο Γαληνός"
+    course: "Βιοπληροφορική"
+    author: vlamos
+    location: "Εξ αποστάσεως"
   - day: "Τετάρτη"
     time: 13
-    course: computer-programming
-    author: andronikos
-    location: "Εργαστήριο Γαληνός"
+    course: ai
+    author: kerman
+    location: "Εξ αποστάσεως"
   - day: "Τετάρτη"
     time: 15
-    course: ba
-    author: doukakis
-    location: "Αμφιθέατρο 2"
+    course: "Συστήματα Υποστήριξης Αποφάσεων"
+    author: exarchos
+    location: "Εξ αποστάσεως"
+  - day: "Τετάρτη"
+    time: 17
+    course: internet-technologies
+    author: dtsouma
+    location: "Εξ αποστάσεως"
+  - day: "Τετάρτη"
+    time: 19
+    course: "Ασφάλεια Δικτύων Υπολογιστών και Επικοινωνιών"
+    author: dadoyan
+    location: "Εξ αποστάσεως"
 
   - day: "Πέμπτη"
+    time: 9
+    course: soen
+    author: choko
+    location: "Εξ αποστάσεως"
+  - day: "Πέμπτη"
+    time: 11
+    course: information-retrieval
+    author: riggas
+    location: "Εξ αποστάσεως"
+  - day: "Πέμπτη"
     time: 13
-    course: discrete-mathematics
-    author: "Γ. Κατωμέρης"
-    location: "Εργαστήριο Γαληνός"
+    course: "Στοχαστική Ανάλυση Δεδομένων"
+    author: avlon
+    location: "Εξ αποστάσεως"
   - day: "Πέμπτη"
     time: 15
-    course: ba
-    author: doukakis
-    location: "Αμφιθέατρο 2"
+    course: internet-technologies
+    author: dtsouma
+    location: "Εξ αποστάσεως"
   - day: "Πέμπτη"
     time: 17
-    course: computer-programming
-    author: andronikos
-    location: "Εργαστήριο Γαληνός"
-  - day: "Πέμπτη"
-    time: 19
-    course: computer-programming
-    author: andronikos
-    location: "Αμφιθέατρο 1"
+    course: "Βιοπληροφορική"
+    author: exarchos
+    location: "Εξ αποστάσεως"
   
   - day: "Παρασκευή"
-    time: 11
-    course: theory-of-propability
-    author: avlon
+    time: 9
+    course: "Βιοπληροφορική"
+    author: "Γ. Κατωμέρης"
     location: "Αμφιθέατρο 2"
   - day: "Παρασκευή"
-    time: 13
-    course: discrete-mathematics
-    author: "Γ. Κατωμέρης"
-    location: "Εργαστήριο Γαληνός"
+    time: 11
+    course: ai
+    author: riggas
+    location: "Εξ αποστάσεως"
   - day: "Παρασκευή"
-    time: 15
-    course: "Αγγλικά ΙΙ"
-    author: "Σ. Κοζομπόλης"
-    location: "Αίθουσα 1"
+    time: 13
+    course: pattern-recognition
+    author: "Γ. Κατωμέρης"
+    location: "Εξ αποστάσεως"
   - day: "Παρασκευή"
     time: 17
-    course: data-structures
-    author: "Α. Σωτηροπούλου"
-    location: "Εργαστήριο Γαληνός"
+    course: distributed-network-systems
+    author: hristope
+    location: "Εξ αποστάσεως"
+  - day: "Παρασκευή"
+    time: 19
+    course: information-retrieval
+    author: mmarag
+    location: "Εξ αποστάσεως"
 ---
 

--- a/all_collections/_timetables/sem_f.md
+++ b/all_collections/_timetables/sem_f.md
@@ -1,0 +1,106 @@
+---
+title: "Προπτυχιακό Β' Εξάμηνο"
+ref: undergraduate_b
+semester: '2'
+timetable:
+  - day: "Δευτέρα"
+    time: 11
+    course: "Στοχαστική Ανάλυση Δεδομένων" 
+    author: alex
+    location: [https://opencourses.ionio.gr/courses/DDI213/](https://opencourses.ionio.gr/courses/DDI213/)
+  - day: "Δευτέρα"
+    time: 13
+    course: ai
+    author: kerman
+    location: [https://e-class.ionio.gr/courses/NOC122/](https://e-class.ionio.gr/courses/NOC122/)
+  - day: "Δευτέρα"
+    time: 15
+    course: "Ασφάλεια Δικτύων Υπολογιστών και Επικοινωνιών"
+    author: dadoyan
+    location: [https://opencourses.ionio.gr/courses/DDI135](https://opencourses.ionio.gr/courses/DDI135)
+  - day: "Δευτέρα"
+    time: 19
+    course: soen
+    author: choko
+    location: [https://github.com/courses-ionio/sw](https://github.com/courses-ionio/sw)
+    
+  - day: "Τρίτη"
+    time: 11
+    course: discrete-mathematics
+    author: vlamos
+    location: "Αμφιθέατρο 1"
+  - day: "Τρίτη"
+    time: 13
+    course: computer-programming
+    author: andronikos
+    location: "Εργαστήριο Γαληνός"
+  - day: "Τρίτη"
+    time: 15
+    course: computer-programming
+    author: mistral
+    location: "Εργαστήριο Γαληνός"
+
+  - day: "Τετάρτη"
+    time: 9
+    course: discrete-mathematics
+    author: vlamos
+    location: "Αμφιθέατρο 1"
+  - day: "Τετάρτη"
+    time: 11
+    course: theory-of-propability
+    author: alex
+    location: "Εργαστήριο Γαληνός"
+  - day: "Τετάρτη"
+    time: 13
+    course: computer-programming
+    author: andronikos
+    location: "Εργαστήριο Γαληνός"
+  - day: "Τετάρτη"
+    time: 15
+    course: ba
+    author: doukakis
+    location: "Αμφιθέατρο 2"
+
+  - day: "Πέμπτη"
+    time: 13
+    course: discrete-mathematics
+    author: "Γ. Κατωμέρης"
+    location: "Εργαστήριο Γαληνός"
+  - day: "Πέμπτη"
+    time: 15
+    course: ba
+    author: doukakis
+    location: "Αμφιθέατρο 2"
+  - day: "Πέμπτη"
+    time: 17
+    course: computer-programming
+    author: andronikos
+    location: "Εργαστήριο Γαληνός"
+  - day: "Πέμπτη"
+    time: 19
+    course: computer-programming
+    author: andronikos
+    location: "Αμφιθέατρο 1"
+  
+  - day: "Παρασκευή"
+    time: 11
+    course: theory-of-propability
+    author: avlon
+    location: "Αμφιθέατρο 2"
+  - day: "Παρασκευή"
+    time: 13
+    course: discrete-mathematics
+    author: "Γ. Κατωμέρης"
+    location: "Εργαστήριο Γαληνός"
+  - day: "Παρασκευή"
+    time: 15
+    course: "Αγγλικά ΙΙ"
+    author: "Σ. Κοζομπόλης"
+    location: "Αίθουσα 1"
+  - day: "Παρασκευή"
+    time: 17
+    course: data-structures
+    author: "Α. Σωτηροπούλου"
+    location: "Εργαστήριο Γαληνός"
+---
+

--- a/all_collections/_timetables/sem_f.md
+++ b/all_collections/_timetables/sem_f.md
@@ -89,7 +89,7 @@ timetable:
   - day: "Πέμπτη"
     time: 9
     course: soen
-    author: choko
+    author: riggas
     location: "Εξ αποστάσεως"
   - day: "Πέμπτη"
     time: 11
@@ -116,7 +116,7 @@ timetable:
     time: 9
     course: "Βιοπληροφορική"
     author: "Γ. Κατωμέρης"
-    location: "Αμφιθέατρο 2"
+    location: "Εξ αποστάσεως"
   - day: "Παρασκευή"
     time: 11
     course: ai

--- a/all_collections/_timetables/sem_f.md
+++ b/all_collections/_timetables/sem_f.md
@@ -7,22 +7,22 @@ timetable:
     time: 11
     course: "Στοχαστική Ανάλυση Δεδομένων" 
     author: alex
-    location: [https://opencourses.ionio.gr/courses/DDI213/](https://opencourses.ionio.gr/courses/DDI213/)
+    location: "Εξ αποστάσεως"
   - day: "Δευτέρα"
     time: 13
     course: ai
     author: kerman
-    location: [https://e-class.ionio.gr/courses/NOC122/](https://e-class.ionio.gr/courses/NOC122/)
+    location: "Εξ αποστάσεως"
   - day: "Δευτέρα"
     time: 15
     course: "Ασφάλεια Δικτύων Υπολογιστών και Επικοινωνιών"
     author: dadoyan
-    location: [https://opencourses.ionio.gr/courses/DDI135](https://opencourses.ionio.gr/courses/DDI135)
+    location: "Εξ αποστάσεως"
   - day: "Δευτέρα"
     time: 19
     course: soen
     author: choko
-    location: [https://github.com/courses-ionio/sw](https://github.com/courses-ionio/sw)
+    location: "Εξ αποστάσεως"
     
   - day: "Τρίτη"
     time: 11

--- a/all_collections/_timetables/sem_f.md
+++ b/all_collections/_timetables/sem_f.md
@@ -1,7 +1,7 @@
 ---
-title: "Προπτυχιακό Β' Εξάμηνο"
-ref: undergraduate_b
-semester: '2'
+title: "Προπτυχιακό ΣΤ' Εξάμηνο"
+ref: undergraduate_f
+semester: '6'
 timetable:
   - day: "Δευτέρα"
     time: 11


### PR DESCRIPTION
### Σχετικό Issue
closes #53

### Προτεινόμενες Αλλαγές

-  Προσθήκη του Ωρολόγιου προγράμματος "Προπτυχιακό ΣΤ' Εξάμηνο" στην υποσελίδα "Ωρολόγιο Πρόγραμμα"



Netlify [Πρόγραμμα "Προπτυχιακό ΣΤ' Εξάμηνο"](https://priceless-goldstine-674c39.netlify.app/timetables/sem_f/)

### Υπενθυμίσεις
- [x] Έχω ανοίξει από πριν issue για τον καλό συντονισμό του project, το οποίο έχει πάρει το πράσινο φως με την αντίστοιχη ετικέτα
- [x] Έχω ενημερώσει το issueNo παραπάνω με τον αριθμό του αντίστοιχου θέματος, ώστε να κλείσει αυτόματα με την αποδοχή αυτού του αιτήματος
- [x] Έχω δημιουργήσει branch για τις αλλαγές
