### PR TITLE
Προσθήκη του Κ. Βόγκλη ως Ακαδημαϊκό Υπότροφο

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -490,3 +490,13 @@ mouratidis-en:
  uri: "https://research.brighton.ac.uk/en/persons/haris-mouratidis"
  bio: "Prof of Software Systems Engineering"
  avatar: "/assets/images/mouratidis.jpg"
+ 
+voglis:
+ name: "Κωνσταντίνος Βόγκλης"
+ email: "voglis@ionio.gr"
+ avatar: "/assets/images/nophoto.jpg"
+
+voglis-en:
+ name: "Konstantinos Vogklis"
+ email: "voglis@ionio.gr"
+ avatar: "/assets/images/nophoto.jpg"


### PR DESCRIPTION
### Σχετικό Issue
closes #249 

### Σχετικό Pull Request στο all_collections
ioniodi/all_collections#15

### Συνεργάτες που θα κάνουν σχόλια ή θα αξιολογήσουν τις αλλαγές (κάντε mention @ τουλάχιστον δύο)
 @john7665 @ApoLaz

### Προτεινόμενες Αλλαγές
--  Προσθήκη του Κ. Βόγκλη στο αρχείο _data/authors.yml. Στο [di.ionio](https://di.ionio.gr/gr/department/staff/691-vogklis/) υπάρχει μόνο το όνομα και το e-mail, οπότε μόνο αυτά πρόσθεσα, μαζί με το asset nophoto.jpg, που υπάρχει και σε άλλους καθηγητές.

### [Demo](https://p17anto2-sitegr-demo.netlify.app/people/)

### Υπενθυμίσεις
- [x] Έχω ανοίξει από πριν issue για τον καλό συντονισμό του project, το οποίο έχει πάρει το πράσινο φως με την αντίστοιχη ετικέτα
- [x] Έχω ενημερώσει το issueNo παραπάνω με τον αριθμό του αντίστοιχου θέματος, ώστε να κλείσει αυτόματα με την αποδοχή αυτού του αιτήματος
- [x] Έχω δημιουργήσει branch για τις αλλαγές
